### PR TITLE
Correct CacheHook description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can configure the `SecretCacheConfiguration` object with the following param
 * `MaxCacheSize` - The maximum number of items the Cache can contain before evicting using LRU. The default value is `1024`.
 * `VersionStage` - The Version Stage the Cache will request when retrieving secrets from Secrets Manager. The default value is `AWSCURRENT`.
 * `Client` - The Secrets Manager client to be used by the Cache. The default value is `null`, which causes the Cache to instantiate a new Secrets Manager client.
-* `CacheHook` - An implementation of the SecretCacheHook abstract class. The default value is `null`.
+* `CacheHook` - An implementation of the ISecretCacheHook interface. The default value is `null`.
 
 ## Getting Help
 We use GitHub issues for tracking bugs and caching library feature requests and have limited bandwidth to address them. Please use these community resources for getting help:


### PR DESCRIPTION
The CacheHook configuration property has a type of ISecretCacheHook, which is an interface. I've just corrected this from "SecretCacheHook abstract class" which doesn't exist.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
