### PR TITLE
Correct README, add .gitignore, fix string formatting bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+######################################
+# Visual Studio per-user settings data
+######################################
+*.suo
+*.user
+
+####################
+# Build/Test folders
+####################
+**/.vs/
+**/bin/
+**/obj/
+**/TestResults/
+**/Temp/
+**/NuGet.exe
+**/buildlogs/
+**/Deployment/
+**/packages
+**/launchSettings.json
+
+**/node_modules/
+**/TestGenerations/
+
+**/.vscode
+**/.idea
+*.userprefs

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can configure the `SecretCacheConfiguration` object with the following param
 * `MaxCacheSize` - The maximum number of items the Cache can contain before evicting using LRU. The default value is `1024`.
 * `VersionStage` - The Version Stage the Cache will request when retrieving secrets from Secrets Manager. The default value is `AWSCURRENT`.
 * `Client` - The Secrets Manager client to be used by the Cache. The default value is `null`, which causes the Cache to instantiate a new Secrets Manager client.
-* `CacheHook` - An implementation of the SecretCacheHook abstract class. The default value is `null`.
+* `CacheHook` - An implementation of the ISecretCacheHook interface. The default value is `null`.
 
 ## Getting Help
 We use GitHub issues for tracking bugs and caching library feature requests and have limited bandwidth to address them. Please use these community resources for getting help:

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
@@ -57,12 +57,12 @@ namespace Amazon.SecretsManager.Extensions.Caching
 
         public override int GetHashCode()
         {
-            return String.Format("%s", secretId).GetHashCode();
+            return (secretId ?? string.Empty).GetHashCode();
         }
 
         public override string ToString()
         {
-            return String.Format("SecretCacheItem: %s", secretId);
+            return $"SecretCacheItem: {secretId}";
         }
 
         public override bool Equals(object obj)

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
@@ -26,7 +26,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             : base(secretId, client, config)
         {
             this.versionId = versionId;
-            this.hash = String.Format("%s %s", secretId, versionId).GetHashCode();
+            this.hash = $"{secretId} {versionId}".GetHashCode();
         }
 
         public override bool Equals(object obj)
@@ -43,7 +43,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
 
         public override string ToString()
         {
-            return String.Format("SecretCacheVersion: %s %v", secretId, versionId);
+            return $"SecretCacheVersion: {secretId} {versionId}";
         }
 
         /// <summary>


### PR DESCRIPTION
This includes PR #4.

Changes in this PR:

1. Correct the README. The CacheHook configuration property has a type of ISecretCacheHook, which is an interface. I've just corrected this from "SecretCacheHook abstract class" which doesn't exist.

2. I've added a copy of the .gitignore from [https://github.com/aws/aws-extensions-for-dotnet-cli/blob/master/.gitignore](aws/aws-extensions-for-dotnet-cli)

3. I've fixed four instances where `%s` or `%v` were being used with `string.Format` which is not supported. This was a bug. For example, GetHashCode in SecretCacheItem would always return the hash code for the string literal "%s", rather than substituting in `secretId` as I imagine the author intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
