### PR TITLE
Removing nextRefreshTime, updating SlidingExpiration to AbsoluteExpir…

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
@@ -27,10 +27,6 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// The cached secret value versions for this cached secret. 
         private readonly MemoryCache versions = new MemoryCache(new MemoryCacheOptions());
         private const ushort MAX_VERSIONS_CACHE_SIZE = 10;
-
-        /// The next scheduled refresh time for this item.  Once the item is accessed
-        /// after this time, the item will be synchronously refreshed.
-        private long nextRefreshTime = 0;
         
         public SecretCacheItem(String secretId, IAmazonSecretsManager client, SecretCacheConfiguration config)
             : base(secretId, client, config)
@@ -43,10 +39,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// </summary>
         protected override async Task<DescribeSecretResponse> ExecuteRefreshAsync()
         {
-            DescribeSecretResponse response = await client.DescribeSecretAsync(new DescribeSecretRequest { SecretId = secretId });
-            int ttl = Convert.ToInt32(config.CacheItemTTL);
-            nextRefreshTime = Environment.TickCount + SecretCacheObject<DescribeSecretRequest>.random.Value.Next(ttl / 2, ttl + 1);
-            return response;
+            return await client.DescribeSecretAsync(new DescribeSecretRequest { SecretId = secretId });
         }
 
         /// <summary>

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -62,7 +62,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             this.secretsManager = secretsManager;
             cacheItemPolicy = new MemoryCacheEntryOptions()
             {
-                SlidingExpiration = TimeSpan.FromMilliseconds(this.config.CacheItemTTL)
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(this.config.CacheItemTTL)
             };
             if (this.secretsManager is AmazonSecretsManagerClient sm)
             {


### PR DESCRIPTION
…ationRelativeToNow

*Issue #, if available:*

*Description of changes:*
See the dialogue on this customer pull request: https://github.com/aws/aws-secretsmanager-caching-net/pull/5

I incorrectly left `nextRefreshTime` in `SecretCacheItem`. I had intended to delete the use of `nextRefreshTime` in all files and only use `AbsoluteExpiration` in the MemoryCache. This is much cleaner in my opinion, and we only have to set the TTL once in code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
