### PR TITLE
Widen Library Compatibility

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -9,11 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.100.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
+
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
 


### PR DESCRIPTION
For example, AWS Lambda Functions have a shared framework at version 2.1.12. This shared framework supports Microsoft.Extensions.* libraries with a version constraint of `< 2.2.0`. There is nothing in this library which requires the extensions' caching library at version 2.2.0, so it has been reduced to 2.1.2.

*Issue #, if available:*

It will close #9, but I have created no issue for this myself.

*Description of changes:*

Reduces version of dependency `Microsoft.Extensions.Caching.Memory` to 2.1.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
