### PR TITLE
Add interface for SecretsManagerCache

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+namespace Amazon.SecretsManager.Extensions.Caching
+{
+
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A class used for clide-side caching of secrets stored in AWS Secrets Manager
+    /// </summary>
+    public interface ISecretsManagerCache : IDisposable
+    {
+
+        /// <summary>
+        /// Returns the cache entry corresponding to the specified secret if it exists in the cache.
+        /// Otherwise, the secret value is fetched from Secrets Manager and a new cache entry is created.
+        /// </summary>
+        SecretCacheItem GetCachedSecret(string secretId);
+
+        /// <summary>
+        /// Asynchronously retrieves the specified SecretBinary after calling <see cref="GetCachedSecret"/>.
+        /// </summary>
+        Task<byte[]> GetSecretBinary(string secretId);
+
+        /// <summary>
+        /// Asynchronously retrieves the specified SecretString after calling <see cref="GetCachedSecret"/>.
+        /// </summary>
+        Task<string> GetSecretString(string secretId);
+
+        /// <summary>
+        /// Requests the secret value from SecretsManager asynchronously and updates the cache entry with any changes.
+        /// If there is no existing cache entry, a new one is created.
+        /// Returns true or false depending on if the refresh is successful.
+        /// </summary>
+        Task<bool> RefreshNowAsync(string secretId);
+    }
+}

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -22,7 +22,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
     /// <summary>
     /// A class used for clide-side caching of secrets stored in AWS Secrets Manager
     /// </summary>
-    public class SecretsManagerCache : IDisposable
+    public class SecretsManagerCache : ISecretsManagerCache
     {
         private readonly IAmazonSecretsManager secretsManager;
         private readonly SecretCacheConfiguration config;
@@ -69,7 +69,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
                 sm.BeforeRequestEvent += this.ServiceClientBeforeRequestEvent;
             }
         }
-        
+
         private void ServiceClientBeforeRequestEvent(object sender, RequestEventArgs e)
         {
             if (e is WebServiceRequestEventArgs args && args.Headers.ContainsKey(VersionInfo.USER_AGENT_HEADER))


### PR DESCRIPTION
*Issue #, if available:* 14

*Description of changes:* An interface (ISecretsManagerCache) was extracted from SecretsManagerCache . This gives us the ability to mock. The Startup service registration can be set to something like this 

```
services.AddTransient<ISecretsManagerCache, SecretsManagerCache>(option =>
                new SecretsManagerCache(
                    new SecretCacheConfiguration
                    {
                        Client = option.GetRequiredService<IAmazonSecretsManager>(),
                        CacheItemTTL = 360000000
                    }
                )
            );
```

and the interface can automatically be injected into constructors

```
     public SomeClass(ISecretsManagerCache secretManagerCache) 
        {
            _secretCache = secretManagerCache;
        }
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
