### PR TITLE
Update tests for .NET Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 **/.vscode
 **/.idea
 *.userprefs
+**.DS_Store

--- a/SecretsManagerCachingDotNet.sln
+++ b/SecretsManagerCachingDotNet.sln
@@ -7,9 +7,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{73B3E414-F5D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C6D686A7-A7EF-4396-9476-70A3A0FB9DEC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.SecretsManager.Extensions.Caching", "src\Amazon.SecretsManager.Extensions.Caching\Amazon.SecretsManager.Extensions.Caching.csproj", "{B7809806-7B35-4712-8995-30BB71218FE9}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.SecretsManager.Extensions.Caching", "src\Amazon.SecretsManager.Extensions.Caching\Amazon.SecretsManager.Extensions.Caching.csproj", "{B7809806-7B35-4712-8995-30BB71218FE9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.SecretsManager.Extensions.Caching.Tests", "test\Amazon.SecretsManager.Extensions.Caching.Tests\Amazon.SecretsManager.Extensions.Caching.Tests.csproj", "{4D691B6D-9E43-484F-9F7B-031EEC709D61}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.SecretsManager.Extensions.Caching.Tests", "test\Amazon.SecretsManager.Extensions.Caching.Tests\Amazon.SecretsManager.Extensions.Caching.Tests.csproj", "{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solutionitems", "solutionitems", "{219B6F8C-9706-408E-8584-45045335DAAF}"
 	ProjectSection(SolutionItems) = preProject
@@ -27,17 +27,17 @@ Global
 		{B7809806-7B35-4712-8995-30BB71218FE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7809806-7B35-4712-8995-30BB71218FE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7809806-7B35-4712-8995-30BB71218FE9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4D691B6D-9E43-484F-9F7B-031EEC709D61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4D691B6D-9E43-484F-9F7B-031EEC709D61}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D691B6D-9E43-484F-9F7B-031EEC709D61}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4D691B6D-9E43-484F-9F7B-031EEC709D61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B7809806-7B35-4712-8995-30BB71218FE9} = {73B3E414-F5D8-4495-A283-D4271126C53A}
-		{4D691B6D-9E43-484F-9F7B-031EEC709D61} = {C6D686A7-A7EF-4396-9476-70A3A0FB9DEC}
+		{72B442BD-CE77-4EF9-AF26-EBD4FD6B8972} = {C6D686A7-A7EF-4396-9476-70A3A0FB9DEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1A5339B2-E624-44ED-B714-2F21D7406ED3}

--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -1,20 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CodeAnalysisRuleSet>..\..\code-analysis.ruleset</CodeAnalysisRuleSet>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <CodeAnalysisRuleSet>..\..\code-analysis.ruleset</CodeAnalysisRuleSet>
+        <OutputType>Library</OutputType>
+        <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
+        <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
+        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+        <PackageId>AWSSDK.SecretsManager.Caching</PackageId>
+        <PackageVersion>1.0.4</PackageVersion>
+        <Title>AWS Secrets Manager Caching for .NET</Title>
+        <Authors>Amazon Web Services</Authors>
+        <Description>The AWS Secrets Manager .NET caching client enables in-process caching of secrets for C# applications.</Description>
+        <Copyright>Amazon Web Services</Copyright>
+        <PackageProjectUrl>https://github.com/aws/aws-secretsmanager-caching-net</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageIconUrl>https://media.amazonwebservices.com/aws_singlebox_01.png</PackageIconUrl>
+        <RepositoryUrl>https://github.com/aws/aws-secretsmanager-caching-net</RepositoryUrl>
+        <PackageTags>AWS;Amazon;cloud;aws-sdk-v3;secrets;secret manager;secretsmanager;caching;cache</PackageTags>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="3.3.100.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-
+    <ItemGroup>
+        <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.1.10" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/test/Amazon.SecretsManager.Extensions.Caching.Tests/Amazon.SecretsManager.Extensions.Caching.Tests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.Tests/Amazon.SecretsManager.Extensions.Caching.Tests.csproj
@@ -1,19 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
+        <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->
+        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageReference Include="Moq" Version="4.16.1"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+        <PackageReference Include="coverlet.collector" Version="3.1.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Amazon.SecretsManager.Extensions.Caching\Amazon.SecretsManager.Extensions.Caching.csproj" />
-  </ItemGroup>
-
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Amazon.SecretsManager.Extensions.Caching\Amazon.SecretsManager.Extensions.Caching.csproj"/>
+    </ItemGroup>
 </Project>

--- a/test/Amazon.SecretsManager.Extensions.Caching.Tests/CacheTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.Tests/CacheTests.cs
@@ -96,7 +96,7 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
         }
 
         [Fact]
-        public void GetSecretStringTest()
+        public async void GetSecretStringTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -107,12 +107,12 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
-            string first = cache.GetSecretString(secretStringResponse1.Name).Result;
+            string first = await cache.GetSecretString(secretStringResponse1.Name);
             Assert.Equal(first, secretStringResponse1.SecretString);
         }
 
         [Fact]
-        public void NoSecretStringPresentTest()
+        public async void NoSecretStringPresentTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -123,12 +123,12 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
-            string first = cache.GetSecretString(secretStringResponse1.Name).Result;
+            string first = await cache.GetSecretString(secretStringResponse1.Name);
             Assert.Null(first);
         }
 
         [Fact]
-        public void GetSecretBinaryTest()
+        public async void GetSecretBinaryTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == binaryResponse1.Name), default(CancellationToken)))
@@ -140,12 +140,12 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
             
-            byte[] first = cache.GetSecretBinary(binaryResponse1.Name).Result;
+            byte[] first = await cache.GetSecretBinary(binaryResponse1.Name);
             Assert.Equal(first, binaryResponse1.SecretBinary.ToArray());
         }
 
         [Fact]
-        public void NoSecretBinaryPresentTest()
+        public async void NoSecretBinaryPresentTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == binaryResponse1.Name), default(CancellationToken)))
@@ -157,12 +157,12 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
 
-            byte[] first = cache.GetSecretBinary(binaryResponse1.Name).Result;
+            byte[] first = await cache.GetSecretBinary(binaryResponse1.Name);
             Assert.Null(first);
         }
 
         [Fact]
-        public void GetSecretBinaryMultipleTest()
+        public async void GetSecretBinaryMultipleTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == binaryResponse1.Name), default(CancellationToken)))
@@ -177,14 +177,14 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
             byte[] first = null;
             for (int i = 0; i < 10; i++)
             {
-                first = cache.GetSecretBinary(binaryResponse1.Name).Result;
+                first = await cache.GetSecretBinary(binaryResponse1.Name);
             }
             Assert.Equal(first, binaryResponse1.SecretBinary.ToArray());
             
         }
 
         [Fact]
-        public void BasicSecretCacheTest()
+        public async void BasicSecretCacheTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -196,14 +196,14 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
             
-            String first = cache.GetSecretString(secretStringResponse1.Name).Result;
-            String second = cache.GetSecretString(secretStringResponse1.Name).Result;
+            String first = await cache.GetSecretString(secretStringResponse1.Name);
+            String second = await cache.GetSecretString(secretStringResponse1.Name);
             Assert.Equal(first, second);
             
         }
 
         [Fact]
-        public void SecretStringRefreshNowTest()
+        public async void SecretStringRefreshNowTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -217,16 +217,16 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
             {
-                String first = cache.GetSecretString(secretStringResponse1.Name).Result;
-                bool success = cache.RefreshNowAsync(secretStringResponse1.Name).Result;
-                String second = cache.GetSecretString(secretStringResponse1.Name).Result;
+                String first = await cache.GetSecretString(secretStringResponse1.Name);
+                bool success = await cache.RefreshNowAsync(secretStringResponse1.Name);
+                String second = await cache.GetSecretString(secretStringResponse1.Name);
                 Assert.True(success);
                 Assert.NotEqual(first, second);
             }
         }
 
         [Fact]
-        public void BinarySecretRefreshNowTest()
+        public async void BinarySecretRefreshNowTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == binaryResponse1.Name), default(CancellationToken)))
@@ -239,15 +239,15 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
-            byte[] first = cache.GetSecretBinary(binaryResponse1.Name).Result;
-            bool success = cache.RefreshNowAsync(binaryResponse1.Name).Result;
-            byte[] second = cache.GetSecretBinary(binaryResponse1.Name).Result;
+            byte[] first = await cache.GetSecretBinary(binaryResponse1.Name);
+            bool success = await cache.RefreshNowAsync(binaryResponse1.Name);
+            byte[] second = await cache.GetSecretBinary(binaryResponse1.Name);
             Assert.True(success);
             Assert.NotEqual(first, second);
         }
 
         [Fact]
-        public void RefreshNowFailedTest()
+        public async void RefreshNowFailedTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -258,15 +258,15 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
                 .ThrowsAsync(new AmazonServiceException("Caught exception"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
-            String first = cache.GetSecretString(secretStringResponse1.Name).Result;
-            bool success = cache.RefreshNowAsync(secretStringResponse1.Name).Result;
-            String second = cache.GetSecretString(secretStringResponse2.Name).Result;
+            String first = await cache.GetSecretString(secretStringResponse1.Name);
+            bool success = await cache.RefreshNowAsync(secretStringResponse1.Name);
+            String second = await cache.GetSecretString(secretStringResponse2.Name);
             Assert.False(success);
             Assert.Equal(first, second);
         }
 
         [Fact]
-        public void BasicSecretCacheTTLRefreshTest()
+        public async void BasicSecretCacheTTLRefreshTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -280,17 +280,17 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object, new SecretCacheConfiguration { CacheItemTTL = 1000 });
             
-            String first = cache.GetSecretString(secretStringResponse1.Name).Result;
-            String second = cache.GetSecretString(secretStringResponse1.Name).Result;
+            String first = await cache.GetSecretString(secretStringResponse1.Name);
+            String second = await cache.GetSecretString(secretStringResponse1.Name);
             Assert.Equal(first, second);
 
             Thread.Sleep(5000);
-            String third = cache.GetSecretString(secretStringResponse2.Name).Result;
+            String third = await cache.GetSecretString(secretStringResponse2.Name);
             Assert.NotEqual(second, third);
         }
 
         [Fact]
-        public void GetSecretStringMultipleTest()
+        public async void GetSecretStringMultipleTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -304,13 +304,13 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
             String first = null;
             for (int i = 0; i < 10; i++)
             {
-                first = cache.GetSecretString(secretStringResponse1.Name).Result;
+                first = await cache.GetSecretString(secretStringResponse1.Name);
             }
             Assert.Equal(first, secretStringResponse1.SecretString);
         }
 
         [Fact]
-        public void TestBasicCacheEviction()
+        public async void TestBasicCacheEviction()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
@@ -327,9 +327,9 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object, new SecretCacheConfiguration { MaxCacheSize = 1 });
-            String first = cache.GetSecretString(secretStringResponse1.Name).Result;
-            String second = cache.GetSecretString(secretStringResponse3.Name).Result;
-            String third = cache.GetSecretString(secretStringResponse2.Name).Result;
+            String first = await cache.GetSecretString(secretStringResponse1.Name);
+            String second = await cache.GetSecretString(secretStringResponse3.Name);
+            String third = await cache.GetSecretString(secretStringResponse2.Name);
             Assert.NotEqual(first, third);
         }
 
@@ -351,7 +351,7 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
         }
 
         [Fact]
-        public void ExceptionRetryTest()
+        public async void ExceptionRetryTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.DescribeSecretAsync(It.IsAny<DescribeSecretRequest>(), default(CancellationToken)))
@@ -365,7 +365,6 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
             Exception ex = null;
             for (int i = 0; i < retryCount; i++)
             {
-                ex = null;
                 try
                 {
                     result = cache.GetSecretString("").Result;
@@ -377,13 +376,14 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
             // Wait for backoff interval before retrying to verify a retry is performed.
             Thread.Sleep(2100);
 
-            ex = null;
             try
             {
-                result = cache.GetSecretString("").Result;
+                await cache.GetSecretString("");
             }
-            catch (AggregateException exception) { ex = exception.InnerException; }
-            Assert.Equal("Expected exception 2", ex.Message);
+            catch (AmazonServiceException exception)
+            {
+                Assert.Equal("Expected exception 2", exception.Message);
+            }
         }
 
         class TestHook : ISecretCacheHook
@@ -408,7 +408,7 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
         }
 
         [Fact]
-        public void HookSecretCacheTest()
+        public async void HookSecretCacheTest()
         {
             Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
             secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.IsAny<GetSecretValueRequest>(), default(CancellationToken)))
@@ -425,13 +425,13 @@ namespace Amazon.SecretsManager.Extensions.Caching.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                Assert.Equal(cache.GetSecretString(secretStringResponse1.Name).Result, secretStringResponse1.SecretString);
+                Assert.Equal(await cache.GetSecretString(secretStringResponse1.Name), secretStringResponse1.SecretString);
             }
             Assert.Equal(2, testHook.GetCount());
 
             for (int i = 0; i < 10; i++)
             {
-                Assert.Equal(cache.GetSecretBinary(binaryResponse1.Name).Result, binaryResponse1.SecretBinary.ToArray());
+                Assert.Equal(await cache.GetSecretBinary(binaryResponse1.Name), binaryResponse1.SecretBinary.ToArray());
             }
             Assert.Equal(4, testHook.GetCount());
         }

--- a/test/Amazon.SecretsManager.Extensions.Caching.Tests/IntegrationTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.Tests/IntegrationTests.cs
@@ -4,35 +4,36 @@
     using Amazon.SecretsManager.Model;
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
 
     // Performs test secret cleanup before and after integ tests are run
-    public class TestBase : IDisposable
+    public class TestBase : IAsyncLifetime
     {
-        public static IAmazonSecretsManager Client = new AmazonSecretsManagerClient();
+        public static IAmazonSecretsManager Client = new AmazonSecretsManagerClient(Amazon.RegionEndpoint.USWest2);
         public static String TestSecretPrefix = "IntegTest";
         public static List<String> SecretNamesToDelete = new List<String>();
 
-        public TestBase()
+        public async Task InitializeAsync()
         {
-            FindPreviousTestSecrets();
-            DeleteSecrets(forceDelete: false);
+            await FindPreviousTestSecrets();
+            await DeleteSecrets(forceDelete: false);
         }
 
-        public void Dispose()
+        public async Task DisposeAsync()
         {
-            DeleteSecrets(forceDelete: true);
+            await DeleteSecrets(forceDelete: true);
         }
 
-        private void FindPreviousTestSecrets()
+        private async Task FindPreviousTestSecrets()
         {
             String nextToken = null;
             var twoDaysAgo = DateTime.Now.AddDays(-2);
             do
             {
-                var response = TestBase.Client.ListSecrets(new ListSecretsRequest { NextToken = nextToken });
+                var response = await TestBase.Client.ListSecretsAsync(new ListSecretsRequest { NextToken = nextToken });
                 nextToken = response.NextToken;
                 List<SecretListEntry> secretList = response.SecretList;
                 foreach (SecretListEntry secret in secretList)
@@ -44,16 +45,14 @@
                         SecretNamesToDelete.Add(secret.Name);
                     }
                 }
-                Thread.Sleep(1000);
             } while (nextToken != null);
         }
 
-        private void DeleteSecrets(bool forceDelete)
+        private async Task DeleteSecrets(bool forceDelete)
         {
             foreach (String secretName in SecretNamesToDelete)
             {
-                TestBase.Client.DeleteSecret(new DeleteSecretRequest { SecretId = secretName, ForceDeleteWithoutRecovery = forceDelete });
-                Thread.Sleep(500);
+                await TestBase.Client.DeleteSecretAsync(new DeleteSecretRequest { SecretId = secretName, ForceDeleteWithoutRecovery = forceDelete });
             }
             SecretNamesToDelete.Clear();
         }
@@ -67,7 +66,7 @@
 
         private enum TestType { SecretString = 0, SecretBinary = 1 };
 
-        private String Setup(TestType type)
+        private async Task<string> Setup(TestType type)
         {
             String testSecretName = TestBase.TestSecretPrefix + Guid.NewGuid().ToString();
             CreateSecretRequest req = null;
@@ -81,80 +80,80 @@
                 req = new CreateSecretRequest { Name = testSecretName, SecretBinary = testSecretBinary };
             }
 
-            TestBase.Client.CreateSecret(req);
+            await TestBase.Client.CreateSecretAsync(req);
             TestBase.SecretNamesToDelete.Add(testSecretName);
             return testSecretName;
         }
 
         [Fact]
-        public void GetSecretStringTest()
+        public async void GetSecretStringTest()
         {
-            String testSecretName = Setup(TestType.SecretString);
+            String testSecretName = await Setup(TestType.SecretString);
             cache = new SecretsManagerCache(TestBase.Client);
-            Assert.Equal(cache.GetSecretString(testSecretName).Result, testSecretString);
+            Assert.Equal(await cache.GetSecretString(testSecretName), testSecretString);
         }
 
         [Fact]
-        public void SecretCacheTTLTest()
+        public async void SecretCacheTTLTest()
         {
-            String testSecretName = Setup(TestType.SecretString);
+            String testSecretName = await Setup(TestType.SecretString);
             cache = new SecretsManagerCache(TestBase.Client, new SecretCacheConfiguration { CacheItemTTL = 1000 });
-            String originalSecretString = cache.GetSecretString(testSecretName).Result;
-            TestBase.Client.UpdateSecretAsync(new UpdateSecretRequest { SecretId = testSecretName, SecretString = System.Guid.NewGuid().ToString() });
+            String originalSecretString = await cache.GetSecretString(testSecretName);
+            await TestBase.Client.UpdateSecretAsync(new UpdateSecretRequest { SecretId = testSecretName, SecretString = System.Guid.NewGuid().ToString() });
 
             // Even though the secret is updated, the cached version should be retrieved
-            Assert.Equal(originalSecretString, cache.GetSecretString(testSecretName).Result);
+            Assert.Equal(originalSecretString, await cache.GetSecretString(testSecretName));
 
             Thread.Sleep(1000);
 
             // Cached secret string should be expired and the updated secret string retrieved
-            Assert.NotEqual(originalSecretString, cache.GetSecretString(testSecretName).Result);
+            Assert.NotEqual(originalSecretString, await cache.GetSecretString(testSecretName));
         }
 
         [Fact]
-        public void SecretCacheRefreshTest()
+        public async void SecretCacheRefreshTest()
         {
-            String testSecretName = Setup(TestType.SecretString);
+            String testSecretName = await Setup(TestType.SecretString);
             cache = new SecretsManagerCache(TestBase.Client);
-            String originalSecretString = cache.GetSecretString(testSecretName).Result;
-            TestBase.Client.UpdateSecretAsync(new UpdateSecretRequest { SecretId = testSecretName, SecretString = System.Guid.NewGuid().ToString() });
+            String originalSecretString = await cache.GetSecretString(testSecretName);
+            await TestBase.Client.UpdateSecretAsync(new UpdateSecretRequest { SecretId = testSecretName, SecretString = System.Guid.NewGuid().ToString() });
 
-            Assert.Equal(originalSecretString, cache.GetSecretString(testSecretName).Result);
-            Assert.True(cache.RefreshNowAsync(testSecretName).Result);
-            Assert.NotEqual(originalSecretString, cache.GetSecretString(testSecretName).Result);
+            Assert.Equal(originalSecretString, await cache.GetSecretString(testSecretName));
+            Assert.True(await cache.RefreshNowAsync(testSecretName));
+            Assert.NotEqual(originalSecretString, await cache.GetSecretString(testSecretName));
         }
 
         [Fact]
-        public void NoSecretBinaryTest()
+        public async void NoSecretBinaryTest()
         {
-            String testSecretName = Setup(TestType.SecretString);
+            String testSecretName = await Setup(TestType.SecretString);
             cache = new SecretsManagerCache(TestBase.Client);
-            Assert.Null(cache.GetSecretBinary(testSecretName).Result);
+            Assert.Null(await cache.GetSecretBinary(testSecretName));
         }
 
         [Fact]
-        public void GetSecretBinaryTest()
+        public async void GetSecretBinaryTest()
         {
-            String testSecretName = Setup(TestType.SecretBinary);
+            String testSecretName = await Setup(TestType.SecretBinary);
             cache = new SecretsManagerCache(TestBase.Client);
-            Assert.Equal(cache.GetSecretBinary(testSecretName).Result, testSecretBinary.ToArray());
+            Assert.Equal(await cache.GetSecretBinary(testSecretName), testSecretBinary.ToArray());
         }
 
         [Fact]
-        public void NoSecretStringTest()
+        public async void NoSecretStringTest()
         {
-            String testSecretName = Setup(TestType.SecretBinary);
+            String testSecretName = await Setup(TestType.SecretBinary);
             cache = new SecretsManagerCache(TestBase.Client);
-            Assert.Null(cache.GetSecretString(testSecretName).Result);
+            Assert.Null(await cache.GetSecretString(testSecretName));
         }
 
         [Fact]
-        public void CacheHookTest()
+        public async void CacheHookTest()
         {
-            String testSecretName = Setup(TestType.SecretString);
+            String testSecretName = await Setup(TestType.SecretString);
             TestHook testHook = new TestHook();
             cache = new SecretsManagerCache(TestBase.Client, new SecretCacheConfiguration { CacheHook = testHook });
-            String originalSecretString = cache.GetSecretString(testSecretName).Result;
+            String originalSecretString = await cache.GetSecretString(testSecretName);
         }
 
         class TestHook : ISecretCacheHook


### PR DESCRIPTION
*Description of changes: 

- .NET Core cannot make synchronous API calls to Secrets Manager. This updates all synchronous API calls to async. 
- Replaced a lot of usages of `Task.Result` with `await` which significantly speeds up the tests ([Relevant StackOverflow](https://stackoverflow.com/questions/32239661/await-vs-task-result-in-an-async-method)). Without this, tests time out in Github Actions.
- Added .NET Core and .NET 5/6 to the test targets.
- Added package information as `csproj` metadata.
- Updated dependencies and incremented version number.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
