### PR TITLE
.NET Core 2.1 EOL

### DIFF
--- a/test/Amazon.SecretsManager.Extensions.Caching.Tests/Amazon.SecretsManager.Extensions.Caching.Tests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.Tests/Amazon.SecretsManager.Extensions.Caching.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
         <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->


### PR DESCRIPTION
.NET Core 2.1 is [end-of-life as of a month ago](https://dotnet.microsoft.com/download/dotnet/2.1). Microsoft has stopped providing .NET Core 2.1 in their Docker images. This PR unblocks our CICD. The library is still tested in .NET Core 3.1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
