### PR TITLE
Require .NET Framework 4.6.2 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The AWS Secrets Manager caching client enables in-process caching of secrets for
 To use this client, you must have:
 
 * A .NET project with one of the following:
-    * .NET Framework 4.6.1 or higher
+    * .NET Framework 4.6.2 or higher
     * .NET Standard 2.0 or higher
 
 * An Amazon Web Services (AWS) account to access secrets stored in AWS Secrets Manager and use AWS SDK for .NET.

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net461</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
         <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net461</TargetFrameworks>
+        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
         <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->


### PR DESCRIPTION
*Issue #, if available:* Require .NET Framework 4.6.2 or later to resolve dependency conflicts. Alternative would be to revert the dependency upgrades. Upgrading to .NET Framework 4.6.2
- partially conflicts with [.NET Standard 2.0 guidelines](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0), however the guidelines strongly advise customers to upgrade to 4.6.2 or later.
- Ensures customers are not calling AWS with TLS 1.0 or 1.1, which are slated for deprecation [soon](https://aws.amazon.com/blogs/security/tls-1-2-required-for-aws-endpoints/)

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
