### PR TITLE
.NET Core 3.1 is end-of-life

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -5,8 +5,6 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <CodeAnalysisRuleSet>..\..\code-analysis.ruleset</CodeAnalysisRuleSet>
         <OutputType>Library</OutputType>
-        <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
-        <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
         <PackageId>AWSSDK.SecretsManager.Caching</PackageId>
         <PackageVersion>1.0.6</PackageVersion>

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
-        <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     </PropertyGroup>
 
@@ -12,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
         <PackageReference Include="Moq" Version="4.18.4"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="coverlet.collector" Version="3.1.2"/>
     </ItemGroup>
 

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <!--        Addresses breaking change from .NET 5.0 to 6.0 in advance-->
-        <!--        https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces-->
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     </PropertyGroup>
 
@@ -12,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
         <PackageReference Include="Moq" Version="4.18.4"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="coverlet.collector" Version="3.1.2"/>
     </ItemGroup>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
