### PR TITLE
feat: get secrets by `versionId` or `versionStage` (#27)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
+Please enable the removal of trailing whitespaces in your IDE. In JetBrains IDEs, enable the following settings under `Settings -> Editor -> General`:
+
+![JetBrains settings](https://private-user-images.githubusercontent.com/66992519/430139096-944e54df-a5a3-4655-bf10-93265149ec0b.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ3NDg3MjksIm5iZiI6MTc0NDc0ODQyOSwicGF0aCI6Ii82Njk5MjUxOS80MzAxMzkwOTYtOTQ0ZTU0ZGYtYTVhMy00NjU1LWJmMTAtOTMyNjUxNDllYzBiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDE1VDIwMjAyOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWEwNzdkNGFkMDljOWUyZmQwN2E2YmMyNzhlYTI3YmQxODQ4ZGY4YzRmMDExM2E4NzFlN2RiYjYzZTNjMTc2ZDQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.SPKnCA3FbZUQAcbedzcos2VJdjL95NuSIUFKrfyH5MY)
+
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 

--- a/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
@@ -39,7 +39,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <param name="versionStage">The version stage.</param>
         /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
         /// <returns>The <c>SecretBinary</c>.</returns>
-        Task<byte[]> GetSecretBinary(string secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default);
+        Task<byte[]> GetSecretBinary(string secretId, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously retrieves the specified <c>SecretString</c> after calling <see cref="GetCachedSecret"/>.
@@ -50,7 +50,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <param name="versionStage">The version stage.</param>
         /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
         /// <returns>The <c>SecretString</c>.</returns>
-        Task<string> GetSecretString(string secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default);
+        Task<string> GetSecretString(string secretId, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Requests the secret value from SecretsManager asynchronously and updates the cache entry with any changes.

--- a/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/ISecretsManagerCache.cs
@@ -31,14 +31,26 @@ namespace Amazon.SecretsManager.Extensions.Caching
         SecretCacheItem GetCachedSecret(string secretId);
 
         /// <summary>
-        /// Asynchronously retrieves the specified SecretBinary after calling <see cref="GetCachedSecret"/>.
+        /// Asynchronously retrieves the specified <c>SecretBinary</c> after calling <see cref="GetCachedSecret"/>.
+        /// If both <c>versionId</c> and <c>versionStage</c> are specified, <c>versionId</c> takes precedence.
         /// </summary>
-        Task<byte[]> GetSecretBinary(string secretId, CancellationToken cancellationToken = default);
+        /// <param name="secretId">The secret identifier. This can be the full ARN or the friendly name for the secret.</param>
+        /// <param name="versionId">The version identifier.</param>
+        /// <param name="versionStage">The version stage.</param>
+        /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
+        /// <returns>The <c>SecretBinary</c>.</returns>
+        Task<byte[]> GetSecretBinary(string secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Asynchronously retrieves the specified SecretString after calling <see cref="GetCachedSecret"/>.
+        /// Asynchronously retrieves the specified <c>SecretString</c> after calling <see cref="GetCachedSecret"/>.
+        /// If both <c>versionId</c> and <c>versionStage</c> are specified, <c>versionId</c> takes precedence.
         /// </summary>
-        Task<string> GetSecretString(string secretId, CancellationToken cancellationToken = default);
+        /// <param name="secretId">The secret identifier. This can be the full ARN or the friendly name for the secret.</param>
+        /// <param name="versionId">The version identifier.</param>
+        /// <param name="versionStage">The version stage.</param>
+        /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
+        /// <returns>The <c>SecretString</c>.</returns>
+        Task<string> GetSecretString(string secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Requests the secret value from SecretsManager asynchronously and updates the cache entry with any changes.

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
@@ -46,7 +46,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <summary>
         /// Asynchronously retrieves the GetSecretValueResponse from the proper SecretCacheVersion.
         /// </summary>
-        protected override async Task<GetSecretValueResponse> GetSecretValueAsync(DescribeSecretResponse result, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
+        protected override async Task<GetSecretValueResponse> GetSecretValueAsync(DescribeSecretResponse result, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default)
         {
             SecretCacheVersion version = GetVersion(result, versionId, versionStage);
             if (version == null)
@@ -75,19 +75,19 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// Retrieves the SecretCacheVersion corresponding to the Version Stage
         /// specified by the SecretCacheConfiguration.
         /// </summary>
-        private SecretCacheVersion GetVersion(DescribeSecretResponse describeResult, string versionId = "", string versionStage = "")
+        private SecretCacheVersion GetVersion(DescribeSecretResponse describeResult, string versionId = null, string versionStage = null)
         {
             if (null == describeResult?.VersionIdsToStages) return null;
             String currentVersionId = null;
             foreach (KeyValuePair<String, List<String>> entry in describeResult.VersionIdsToStages)
             {
-                if (versionId != string.Empty && entry.Key.Equals(versionId))
+                if (versionId != null && entry.Key.Equals(versionId))
                 {
                     currentVersionId = versionId;
                     break;
                 }
 
-                if ((versionStage != string.Empty && entry.Value.Contains(versionStage)) || entry.Value.Contains(config.VersionStage))
+                if ((versionStage != null && entry.Value.Contains(versionStage)) || entry.Value.Contains(config.VersionStage))
                 {
                     currentVersionId = entry.Key;
                     break;

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
@@ -25,15 +25,15 @@ namespace Amazon.SecretsManager.Extensions.Caching
     /// </summary>
     public class SecretCacheItem : SecretCacheObject<DescribeSecretResponse>
     {
-        /// The cached secret value versions for this cached secret. 
+        /// The cached secret value versions for this cached secret.
         private readonly MemoryCache versions = new MemoryCache(new MemoryCacheOptions());
         private const ushort MAX_VERSIONS_CACHE_SIZE = 10;
-        
+
         public SecretCacheItem(String secretId, IAmazonSecretsManager client, SecretCacheConfiguration config)
             : base(secretId, client, config)
         {
         }
-        
+
         /// <summary>
         /// Asynchronously retrieves the most current DescribeSecretResponse from Secrets Manager
         /// as part of the Refresh operation.
@@ -46,9 +46,9 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <summary>
         /// Asynchronously retrieves the GetSecretValueResponse from the proper SecretCacheVersion.
         /// </summary>
-        protected override async Task<GetSecretValueResponse> GetSecretValueAsync(DescribeSecretResponse result, CancellationToken cancellationToken = default)
+        protected override async Task<GetSecretValueResponse> GetSecretValueAsync(DescribeSecretResponse result, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
         {
-            SecretCacheVersion version = GetVersion(result);
+            SecretCacheVersion version = GetVersion(result, versionId, versionStage);
             if (version == null)
             {
                 return null;
@@ -75,13 +75,19 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// Retrieves the SecretCacheVersion corresponding to the Version Stage
         /// specified by the SecretCacheConfiguration.
         /// </summary>
-        private SecretCacheVersion GetVersion(DescribeSecretResponse describeResult)
+        private SecretCacheVersion GetVersion(DescribeSecretResponse describeResult, string versionId = "", string versionStage = "")
         {
             if (null == describeResult?.VersionIdsToStages) return null;
             String currentVersionId = null;
             foreach (KeyValuePair<String, List<String>> entry in describeResult.VersionIdsToStages)
             {
-                if (entry.Value.Contains(config.VersionStage))
+                if (versionId != string.Empty && entry.Key.Equals(versionId))
+                {
+                    currentVersionId = versionId;
+                    break;
+                }
+
+                if ((versionStage != string.Empty && entry.Value.Contains(versionStage)) || entry.Value.Contains(config.VersionStage))
                 {
                     currentVersionId = entry.Key;
                     break;

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
@@ -96,7 +96,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
 
         protected abstract Task<T> ExecuteRefreshAsync(CancellationToken cancellationToken = default);
 
-        protected abstract Task<GetSecretValueResponse> GetSecretValueAsync(T result, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default);
+        protected abstract Task<GetSecretValueResponse> GetSecretValueAsync(T result, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return the typed result object.
@@ -209,7 +209,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// If the secret is due for a refresh, the refresh will occur before the result is returned.
         /// If the refresh fails, the cached result is returned, or the cached exception is thrown.
         /// </summary>
-        public async Task<GetSecretValueResponse> GetSecretValue(CancellationToken cancellationToken, string versionId = "", string versionStage = "")
+        public async Task<GetSecretValueResponse> GetSecretValue(CancellationToken cancellationToken, string versionId = null, string versionStage = null)
         {
             bool success = false;
             await Lock.WaitAsync(cancellationToken);

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
@@ -56,7 +56,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             return await this.client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = this.secretId, VersionId = this.versionId }, cancellationToken);
         }
 
-        protected override Task<GetSecretValueResponse> GetSecretValueAsync(GetSecretValueResponse result, CancellationToken cancellationToken = default)
+        protected override Task<GetSecretValueResponse> GetSecretValueAsync(GetSecretValueResponse result, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
         {
             return Task.FromResult(result);
         }

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
@@ -56,7 +56,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             return await this.client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = this.secretId, VersionId = this.versionId }, cancellationToken);
         }
 
-        protected override Task<GetSecretValueResponse> GetSecretValueAsync(GetSecretValueResponse result, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
+        protected override Task<GetSecretValueResponse> GetSecretValueAsync(GetSecretValueResponse result, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(result);
         }

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -86,24 +86,36 @@ namespace Amazon.SecretsManager.Extensions.Caching
         }
 
         /// <summary>
-        /// Asynchronously retrieves the specified SecretString after calling <see cref="GetCachedSecret"/>.
+        /// Asynchronously retrieves the specified <c>SecretString</c> after calling <see cref="GetCachedSecret"/>.
+        /// If both <c>versionId</c> and <c>versionStage</c> are specified, <c>versionId</c> takes precedence.
         /// </summary>
-        public async Task<String> GetSecretString(String secretId, CancellationToken cancellationToken = default)
+        /// <param name="secretId">The secret identifier. This can be the full ARN or the friendly name for the secret.</param>
+        /// <param name="versionId">The version identifier.</param>
+        /// <param name="versionStage">The version stage.</param>
+        /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
+        /// <returns>The <c>SecretString</c>.</returns>
+        public async Task<String> GetSecretString(String secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;
-            response = await secret.GetSecretValue(cancellationToken);
+            response = await secret.GetSecretValue(cancellationToken, versionId, versionStage);
             return response?.SecretString;
         }
 
         /// <summary>
-        /// Asynchronously retrieves the specified SecretBinary after calling <see cref="GetCachedSecret"/>.
+        /// Asynchronously retrieves the specified <c>SecretBinary</c> after calling <see cref="GetCachedSecret"/>.
+        /// If both <c>versionId</c> and <c>versionStage</c> are specified, <c>versionId</c> takes precedence.
         /// </summary>
-        public async Task<byte[]> GetSecretBinary(String secretId, CancellationToken cancellationToken = default)
+        /// <param name="secretId">The secret identifier. This can be the full ARN or the friendly name for the secret.</param>
+        /// <param name="versionId">The version identifier.</param>
+        /// <param name="versionStage">The version stage.</param>
+        /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
+        /// <returns>The <c>SecretBinary</c>.</returns>
+        public async Task<byte[]> GetSecretBinary(String secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;
-            response = await secret.GetSecretValue(cancellationToken);
+            response = await secret.GetSecretValue(cancellationToken, versionId, versionStage);
             return response?.SecretBinary?.ToArray();
         }
 

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -94,7 +94,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <param name="versionStage">The version stage.</param>
         /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
         /// <returns>The <c>SecretString</c>.</returns>
-        public async Task<String> GetSecretString(String secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
+        public async Task<String> GetSecretString(String secretId, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;
@@ -111,7 +111,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <param name="versionStage">The version stage.</param>
         /// <param name="cancellationToken">The cancellation token used for the Secrets Manager API call.</param>
         /// <returns>The <c>SecretBinary</c>.</returns>
-        public async Task<byte[]> GetSecretBinary(String secretId, string versionId = "", string versionStage = "", CancellationToken cancellationToken = default)
+        public async Task<byte[]> GetSecretBinary(String secretId, string versionId = null, string versionStage = null, CancellationToken cancellationToken = default)
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
@@ -140,8 +140,8 @@ namespace Amazon.SecretsManager.Extensions.Caching.UnitTests
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
 
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
-            string first = await cache.GetSecretString(secretStringResponse3.Name, secretStringResponse3.VersionId);
-            Assert.Equal(first, secretStringResponse3.SecretString);
+            string first = await cache.GetSecretString(secretStringResponse1.Name, secretStringResponse1.VersionId);
+            Assert.Equal(first, secretStringResponse1.SecretString);
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:*
#27 

*Description of changes:*
- Add optional `versionId` and `versionStage` args to `GetSecretString` and `GetSecretBinary` to allow retrieving secrets by version ID or version stage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
