### PR TITLE
Upgrade reference to AWS SDK for .NET to the recently GA V4 version.

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -7,7 +7,7 @@
         <OutputType>Library</OutputType>
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
         <PackageId>AWSSDK.SecretsManager.Caching</PackageId>
-        <PackageVersion>2.0.0</PackageVersion>
+        <PackageVersion>3.0.0</PackageVersion>
         <Title>AWS Secrets Manager Caching for .NET</Title>
         <Authors>Amazon Web Services</Authors>
         <Description>The AWS Secrets Manager .NET caching client enables in-process caching of secrets for .NET applications.</Description>
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SecretsManager" Version="3.*" />
+        <PackageReference Include="AWSSDK.SecretsManager" Version="4.*" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.*" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.*">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
+++ b/src/Amazon.SecretsManager.Extensions.Caching/Amazon.SecretsManager.Extensions.Caching.csproj
@@ -7,7 +7,7 @@
         <OutputType>Library</OutputType>
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
         <PackageId>AWSSDK.SecretsManager.Caching</PackageId>
-        <PackageVersion>3.0.0</PackageVersion>
+        <PackageVersion>2.0.0</PackageVersion>
         <Title>AWS Secrets Manager Caching for .NET</Title>
         <Authors>Amazon Web Services</Authors>
         <Description>The AWS Secrets Manager .NET caching client enables in-process caching of secrets for .NET applications.</Description>

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
@@ -39,8 +39,8 @@
                 foreach (SecretListEntry secret in secretList)
                 {
                     if (secret.Name.StartsWith(TestSecretPrefix)
-                        && DateTime.Compare(secret.LastChangedDate.GetValueOrDefault(), twoDaysAgo) < 0
-                        && DateTime.Compare(secret.LastAccessedDate.GetValueOrDefault(), twoDaysAgo) < 0)
+                        && DateTime.Compare(secret.LastChangedDate ?? throw new InvalidOperationException("Nullable value is null."), twoDaysAgo) < 0
+                        && DateTime.Compare(secret.LastAccessedDate ?? throw new InvalidOperationException("Nullable value is null."), twoDaysAgo) < 0)
                     {
                         SecretNamesToDelete.Add(secret.Name);
                     }

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
@@ -39,8 +39,8 @@
                 foreach (SecretListEntry secret in secretList)
                 {
                     if (secret.Name.StartsWith(TestSecretPrefix)
-                        && DateTime.Compare(secret.LastChangedDate, twoDaysAgo) < 0
-                        && DateTime.Compare(secret.LastAccessedDate, twoDaysAgo) < 0)
+                        && DateTime.Compare(secret.LastChangedDate.GetValueOrDefault(), twoDaysAgo) < 0
+                        && DateTime.Compare(secret.LastAccessedDate.GetValueOrDefault(), twoDaysAgo) < 0)
                     {
                         SecretNamesToDelete.Add(secret.Name);
                     }

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/IntegrationTests.cs
@@ -39,8 +39,8 @@
                 foreach (SecretListEntry secret in secretList)
                 {
                     if (secret.Name.StartsWith(TestSecretPrefix)
-                        && DateTime.Compare(secret.LastChangedDate ?? throw new InvalidOperationException("Nullable value is null."), twoDaysAgo) < 0
-                        && DateTime.Compare(secret.LastAccessedDate ?? throw new InvalidOperationException("Nullable value is null."), twoDaysAgo) < 0)
+                        && DateTime.Compare(secret.LastChangedDate ?? throw new InvalidOperationException("Value for LastChangedDate is null."), twoDaysAgo) < 0
+                        && DateTime.Compare(secret.LastAccessedDate ?? throw new InvalidOperationException("Value for LastAccessedDate is null."), twoDaysAgo) < 0)
                     {
                         SecretNamesToDelete.Add(secret.Name);
                     }


### PR DESCRIPTION
*Description of changes:*
The AWS SDK for .NET recently GA the V4 version. https://aws.amazon.com/blogs/developer/general-availability-of-aws-sdk-for-net-v4-0/

Updating this package to V4 unblocks users like this one https://github.com/aws/aws-sdk-net/issues/3362#issuecomment-2707054425 to move their application to V4. 

The V4 is an evolutionary major version and we are expecting users to update fairly quickly and relatively short cycle of dual support with V3.

I made the version bump a major version bump since it forces users to update to V4 of the SDK.

*Testing*
I ran the tests in the solution and scanned the SDK usage for possible null collection issues. In V4 collection properties default to null. Only area I saw that could be a problem was in the `GetVersion` method of `SecretCacheItem` which already had a null check so was safe.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
