### PR TITLE
fix: use OIDC for Codecov

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: windows-latest
@@ -34,4 +38,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           directory: test/Amazon.SecretsManager.Extensions.Caching.UnitTests/TestResults
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          use_oidc: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code coverage broke due to GitHub separating repository secrets from Dependabot secrets. Use the OIDC token to write code coverage data to Codecov.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
