### PR TITLE
Don't capture context in library internal awaits.

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheItem.cs
@@ -40,7 +40,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// </summary>
         protected override async Task<DescribeSecretResponse> ExecuteRefreshAsync(CancellationToken cancellationToken = default)
         {
-            return await client.DescribeSecretAsync(new DescribeSecretRequest { SecretId = secretId }, cancellationToken);
+            return await client.DescribeSecretAsync(new DescribeSecretRequest { SecretId = secretId }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             {
                 return null;
             }
-            return await version.GetSecretValue(cancellationToken);
+            return await version.GetSecretValue(cancellationToken).ConfigureAwait(false);
         }
 
         public override int GetHashCode()

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
@@ -151,7 +151,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             refreshNeeded = false;
             try
             {
-                SetResult(await ExecuteRefreshAsync(cancellationToken));
+                SetResult(await ExecuteRefreshAsync(cancellationToken).ConfigureAwait(false));
                 exception = null;
                 exceptionCount = 0;
                 return true;
@@ -192,10 +192,10 @@ namespace Amazon.SecretsManager.Extensions.Caching
 
             // Perform the requested refresh.
             bool success = false;
-            await Lock.WaitAsync(cancellationToken);
+            await Lock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                success = await RefreshAsync(cancellationToken);
+                success = await RefreshAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -212,10 +212,10 @@ namespace Amazon.SecretsManager.Extensions.Caching
         public async Task<GetSecretValueResponse> GetSecretValue(CancellationToken cancellationToken)
         {
             bool success = false;
-            await Lock.WaitAsync(cancellationToken);
+            await Lock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                success = await RefreshAsync(cancellationToken);
+                success = await RefreshAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -226,7 +226,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
             }
-            return await GetSecretValueAsync(GetResult(), cancellationToken);
+            return await GetSecretValueAsync(GetResult(), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheVersion.cs
@@ -53,7 +53,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// </summary>
         protected override async Task<GetSecretValueResponse> ExecuteRefreshAsync(CancellationToken cancellationToken = default)
         {
-            return await this.client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = this.secretId, VersionId = this.versionId }, cancellationToken);
+            return await this.client.GetSecretValueAsync(new GetSecretValueRequest { SecretId = this.secretId, VersionId = this.versionId }, cancellationToken).ConfigureAwait(false);
         }
 
         protected override Task<GetSecretValueResponse> GetSecretValueAsync(GetSecretValueResponse result, CancellationToken cancellationToken = default)

--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretsManagerCache.cs
@@ -92,7 +92,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;
-            response = await secret.GetSecretValue(cancellationToken);
+            response = await secret.GetSecretValue(cancellationToken).ConfigureAwait(false);
             return response?.SecretString;
         }
 
@@ -103,7 +103,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         {
             SecretCacheItem secret = GetCachedSecret(secretId);
             GetSecretValueResponse response = null;
-            response = await secret.GetSecretValue(cancellationToken);
+            response = await secret.GetSecretValue(cancellationToken).ConfigureAwait(false);
             return response?.SecretBinary?.ToArray();
         }
 
@@ -114,7 +114,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// </summary>
         public async Task<bool> RefreshNowAsync(String secretId, CancellationToken cancellationToken = default)
         {
-            return await GetCachedSecret(secretId).RefreshNowAsync(cancellationToken);
+            return await GetCachedSecret(secretId).RefreshNowAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
@@ -450,5 +450,132 @@ namespace Amazon.SecretsManager.Extensions.Caching.UnitTests
             }
             Assert.Equal(4, testHook.GetCount());
         }
+
+        class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
+        {
+            object _lock;
+            Queue<(SendOrPostCallback, object)> _workQueue;
+            Thread _thread;
+
+            public SingleThreadSynchronizationContext()
+            {
+                _lock = new object();
+                _workQueue = new Queue<(SendOrPostCallback, object)>();
+                _thread = new Thread(ThreadLoop);
+                _thread.Start();
+            }
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                lock (_lock)
+                {
+                    _workQueue.Enqueue((d, state));
+                    Monitor.Pulse(_lock);
+                }
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                ManualResetEvent re = new ManualResetEvent(false);
+                Post((_) =>
+                {
+                    try
+                    {
+                        d(state);
+                    }
+                    finally
+                    {
+                        re.Set();
+                    }
+                }, null);
+                re.WaitOne();
+            }
+
+            void ThreadLoop()
+            {
+                for (;;)
+                {
+                    (SendOrPostCallback, object) item;
+
+                    lock (_lock)
+                    {
+                        for (;;)
+                        {
+                            if (_workQueue == null)
+                                return;
+                            if (_workQueue.Count > 0)
+                            {
+                                item = _workQueue.Dequeue();
+                                break;
+                            }
+                            Monitor.Wait(_lock);
+                        }
+                    }
+
+                    item.Item1.Invoke(item.Item2);
+                }
+            }
+
+            public void Dispose()
+            {
+                lock (_lock)
+                {
+                    _workQueue = null;
+                    Monitor.Pulse(_lock);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test the returned Tasks can be Wait()'ed, regardless on which sychronization
+        /// context the call was made from.
+        /// </summary>
+        [Fact]
+        public async Task DontCaptureContextTest()
+        {
+            // single threaded sync context, simulating UI thread
+            SingleThreadSynchronizationContext syncContext = new SingleThreadSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(syncContext);
+
+            try
+            {
+                await Task.Factory.StartNew(
+                    () =>
+                    {
+                        Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
+                        secretsManager.SetupSequence(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
+                            .Returns(async () =>
+                            {
+                                // Ensure Task returned is not RunToCompletion to get the async callback
+                                await Task.Delay(1).ConfigureAwait(false);
+                                return secretStringResponse1;
+                            })
+                            .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
+                        secretsManager.SetupSequence(i => i.DescribeSecretAsync(It.Is<DescribeSecretRequest>(j => j.SecretId == secretStringResponse1.Name), default(CancellationToken)))
+                            .Returns(async () =>
+                            {
+                                // Ensure Task returned is not RunToCompletion to get the async callback
+                                await Task.Delay(1).ConfigureAwait(false);
+                                return describeSecretResponse1;
+                            })
+                            .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
+
+                        SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
+                        Task<string> getSecretTask = cache.GetSecretString(secretStringResponse1.Name);
+                        if (!getSecretTask.Wait(TimeSpan.FromSeconds(2)))
+                            Assert.Fail("GetSecretString did not complete within the timeout. (It captured the current synchronization context).");
+
+                        Assert.Equal(getSecretTask.Result, secretStringResponse1.SecretString);
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.None,
+                    TaskScheduler.FromCurrentSynchronizationContext());
+            }
+            finally
+            {
+                syncContext.Dispose();
+                SynchronizationContext.SetSynchronizationContext(null);
+            }
+        }
     }
 }


### PR DESCRIPTION
The caller might have some weird synchronization context or task scheduler and the continuations posted on it might not ever complete. Use ConfigureAwait(false) on every await to ensure the continuations are posted on the default thread pool.

*Issue #, if available:*

https://github.com/aws/aws-secretsmanager-caching-net/issues/189

*Description of changes:*

This PR adds `ConfigureAwait(false)` on every `await`. This PR also adds a test simulating use from a UI thread that ensure no deadlocking happens.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
