### PR TITLE
Matrix dotnet build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,20 +12,27 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    name: build (${{ matrix.runner}}, .NET ${{ matrix.dotnet-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run on supported LTS versions
+        runner: [ubuntu-latest, windows-latest]
+        dotnet-version: [10, 8]
+    runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: |
-            8
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install .NET Framework (add MSBuild to Path)
-        uses: microsoft/setup-msbuild@v2
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v3
         with:
-          msbuild-architecture: x64
+          msbuild-architecture: ${{ runner.arch }}
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -33,9 +40,9 @@ jobs:
       - name: Test
         # Strong name requires disabling xUnit app domains in order to get coverage using coverlet
         # https://github.com/MarcoRossignoli/coverlet/blob/master/Documentation/KnownIssues.md#tests-fail-if-assembly-is-strong-named
-        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" test/Amazon.SecretsManager.Extensions.Caching.UnitTests -- RunConfiguration.DisableAppDomain=true
+        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" test/Amazon.SecretsManager.Extensions.Caching.UnitTests ${{ runner.os != 'Windows' && format('--framework net{0}.0', matrix.dotnet-version) || '' }} -- RunConfiguration.DisableAppDomain=true
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           directory: test/Amazon.SecretsManager.Extensions.Caching.UnitTests/TestResults
           fail_ci_if_error: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,13 +12,21 @@ permissions:
 
 jobs:
   build:
-    name: build (${{ matrix.runner}}, .NET ${{ matrix.dotnet-version }})
+    name: build (${{ matrix.runner }}, ${{ matrix.framework }})
     strategy:
       fail-fast: false
       matrix:
-        # Run on supported LTS versions
-        runner: [ubuntu-latest, windows-latest]
-        dotnet-version: [10, 8]
+        include:
+          - runner: ubuntu-latest
+            framework: net8.0
+          - runner: ubuntu-latest
+            framework: net10.0
+          - runner: windows-latest
+            framework: net8.0
+          - runner: windows-latest
+            framework: net10.0
+          - runner: windows-latest
+            framework: net48
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -27,12 +35,14 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            8
+            10
       - name: Install .NET Framework (add MSBuild to Path)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v3
         with:
-          msbuild-architecture: ${{ runner.arch }}
+          msbuild-architecture: x64
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -40,7 +50,7 @@ jobs:
       - name: Test
         # Strong name requires disabling xUnit app domains in order to get coverage using coverlet
         # https://github.com/MarcoRossignoli/coverlet/blob/master/Documentation/KnownIssues.md#tests-fail-if-assembly-is-strong-named
-        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" test/Amazon.SecretsManager.Extensions.Caching.UnitTests ${{ runner.os != 'Windows' && format('--framework net{0}.0', matrix.dotnet-version) || '' }} -- RunConfiguration.DisableAppDomain=true
+        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" test/Amazon.SecretsManager.Extensions.Caching.UnitTests --framework ${{ matrix.framework }} -- RunConfiguration.DisableAppDomain=true
       - name: Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.IntegTests/Amazon.SecretsManager.Extensions.Caching.IntegTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
         <SignAssembly>true</SignAssembly>

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/Amazon.SecretsManager.Extensions.Caching.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
         <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## Description

### Why is this change being made?

1. We do not run unit tests on Linux, only on Windows.


### What is changing?

1. Matrix on OS and the two most recent .NET LTS versions.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Tested on fork

### When testing locally, provide testing artifact(s):

1. https://github.com/simonmarty/aws-secretsmanager-caching-net/actions/runs/23774021117

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:* No integ test changes
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
