### PR TITLE
Fix Lock Contention

### DIFF
--- a/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
+++ b/src/Amazon.SecretsManager.Extensions.Caching/SecretCacheObject.cs
@@ -25,11 +25,11 @@ namespace Amazon.SecretsManager.Extensions.Caching
         private readonly JitteredDelay exceptionJitteredDelay;
         private readonly JitteredDelay forceRefreshJitteredDelay;
 
+        /// A private object to synchronize access to certain methods. 
+        private readonly SemaphoreSlim Lock;
+
         /// The secret identifier for this cached object. 
         protected String secretId;
-
-        /// A private object to synchronize access to certain methods. 
-        protected static readonly SemaphoreSlim Lock = new SemaphoreSlim(1,1);
 
         /// The AWS Secrets Manager client to use for requesting secrets. 
         protected IAmazonSecretsManager client;
@@ -57,8 +57,6 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// The time to wait before retrying a failed AWS Secrets Manager request.
         private DateTime nextRetryTime = DateTime.MinValue;
 
-        public static readonly ThreadLocal<Random> random = new ThreadLocal<Random>(() => new Random(Environment.TickCount));
-
 
 
         /// <summary>
@@ -79,6 +77,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             this.forceRefreshJitteredDelay = new JitteredDelay(
                 config.ForceRefreshDelayBase,
                 config.ForceRefreshDelayJitter);
+            this.Lock = new SemaphoreSlim(1,1);
         }
      
         protected abstract Task<T> ExecuteRefreshAsync(CancellationToken cancellationToken = default);
@@ -162,7 +161,6 @@ namespace Amazon.SecretsManager.Extensions.Caching
         /// <exception cref="System.OperationCanceledException">Thrown when the <paramref name="cancellationToken"/> is cancelled during the backoff delay.</exception>
         public async Task<bool> RefreshNowAsync(CancellationToken cancellationToken = default)
         {
-            refreshNeeded = true;
             // When forcing a refresh, always sleep with a random jitter
             // to prevent coding errors that could be calling refreshNow
             // in a loop.
@@ -185,6 +183,7 @@ namespace Amazon.SecretsManager.Extensions.Caching
             // Perform the requested refresh.
             bool success = false;
             await Lock.WaitAsync(cancellationToken);
+            refreshNeeded = true;
             try
             {
                 success = await RefreshAsync(cancellationToken);

--- a/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
+++ b/test/Amazon.SecretsManager.Extensions.Caching.UnitTests/CacheTests.cs
@@ -585,7 +585,7 @@ namespace Amazon.SecretsManager.Extensions.Caching.UnitTests
                 .ReturnsAsync(describeSecretResponse1)
                 .ReturnsAsync(describeSecretResponse1)
                 .ThrowsAsync(new AmazonSecretsManagerException("This should not be called"));
-            
+
             TestHook testHook = new TestHook();
             SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object, new SecretCacheConfiguration { CacheHook = testHook });
 
@@ -600,6 +600,113 @@ namespace Amazon.SecretsManager.Extensions.Caching.UnitTests
                 Assert.Equal(await cache.GetSecretBinary(binaryResponse1.Name), binaryResponse1.SecretBinary.ToArray());
             }
             Assert.Equal(4, testHook.GetCount());
+        }
+
+        // [UNRELIABLE] Concurrency test
+        [Fact]
+        public async Task ConcurrentGetSecretStringOnlyRefreshesOnce()
+        {
+            int describeCallCount = 0;
+            Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
+            secretsManager.Setup(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(secretStringResponse1);
+            secretsManager.Setup(i => i.DescribeSecretAsync(It.Is<DescribeSecretRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    Interlocked.Increment(ref describeCallCount);
+                    return describeSecretResponse1;
+                });
+
+            SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
+
+            // Fire 20 concurrent requests for the same secret
+            var tasks = Enumerable.Range(0, 20)
+                .Select(_ => cache.GetSecretString(secretStringResponse1.Name))
+                .ToArray();
+
+            string[] results = await Task.WhenAll(tasks);
+
+            // All concurrent callers should receive the correct value
+            foreach (string result in results)
+            {
+                Assert.Equal(secretStringResponse1.SecretString, result);
+            }
+
+            // Only one DescribeSecret call should have been made despite 20 concurrent requests
+            Assert.Equal(1, describeCallCount);
+        }
+
+        // [UNRELIABLE] Concurrency test
+        [Fact]
+        public async Task ConcurrentGetSecretStringDifferentSecretsSucceeds()
+        {
+            Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
+            secretsManager.Setup(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(secretStringResponse1);
+            secretsManager.Setup(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse3.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(secretStringResponse3);
+            secretsManager.Setup(i => i.DescribeSecretAsync(It.Is<DescribeSecretRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(describeSecretResponse1);
+            secretsManager.Setup(i => i.DescribeSecretAsync(It.Is<DescribeSecretRequest>(j => j.SecretId == secretStringResponse3.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(describeSecretResponse1);
+
+            SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object);
+
+            // Interleave requests for two different secrets concurrently
+            var tasks = new List<Task<string>>();
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(cache.GetSecretString(secretStringResponse1.Name));
+                tasks.Add(cache.GetSecretString(secretStringResponse3.Name));
+            }
+
+            string[] results = await Task.WhenAll(tasks);
+
+            // Verify each result matches its corresponding secret (even indices = secret1, odd = secret3)
+            for (int i = 0; i < results.Length; i++)
+            {
+                string expected = i % 2 == 0 ? secretStringResponse1.SecretString : secretStringResponse3.SecretString;
+                Assert.Equal(expected, results[i]);
+            }
+        }
+
+        // [UNRELIABLE] Concurrency test
+        [Fact]
+        public async Task ConcurrentRefreshNowDoesNotCorruptState()
+        {
+            int refreshCount = 0;
+            Mock<IAmazonSecretsManager> secretsManager = new Mock<IAmazonSecretsManager>(MockBehavior.Strict);
+            secretsManager.Setup(i => i.GetSecretValueAsync(It.Is<GetSecretValueRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(secretStringResponse1);
+            secretsManager.Setup(i => i.DescribeSecretAsync(It.Is<DescribeSecretRequest>(j => j.SecretId == secretStringResponse1.Name), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    Interlocked.Increment(ref refreshCount);
+                    return describeSecretResponse1;
+                });
+
+            // Minimal delay so refreshes complete quickly and contention is maximized
+            var fastConfig = new SecretCacheConfiguration
+            {
+                ForceRefreshDelayBase = TimeSpan.FromMilliseconds(1),
+                ForceRefreshDelayJitter = TimeSpan.FromMilliseconds(1)
+            };
+
+            SecretsManagerCache cache = new SecretsManagerCache(secretsManager.Object, fastConfig);
+
+            // Populate the cache first
+            await cache.GetSecretString(secretStringResponse1.Name);
+
+            // Launch 10 concurrent RefreshNowAsync calls to stress internal state transitions
+            var tasks = Enumerable.Range(0, 10)
+                .Select(_ => cache.RefreshNowAsync(secretStringResponse1.Name))
+                .ToArray();
+
+            bool[] results = await Task.WhenAll(tasks);
+
+            // All refreshes should complete successfully, and the cache should remain consistent
+            string value = await cache.GetSecretString(secretStringResponse1.Name);
+            Assert.Equal(secretStringResponse1.SecretString, value);
         }
     }
 }


### PR DESCRIPTION
## Description

### Why is this change being made?

To improve performance of the library, since one secret can't block everyone else now.


### What is changing?

Changed locking from a global lock to a per-secret lock


### Related Links
- **Issue #, if available**:
 - https://taskei.amazon.dev/tasks/Mimir-14342

---

## Testing

### How was this tested?

dotnet test -f net8.0

Note: Some tests could not be run locally as they require running on Windows. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
